### PR TITLE
Get away from master-slave jargon

### DIFF
--- a/code/background.py
+++ b/code/background.py
@@ -85,7 +85,7 @@ def loadraw(challenge,limit=None):
 
 def lnprob(x):
     """logL stub function for emcee. It needs to use global variables because otherwise
-    multiprocessing.map will need to transmit big arrays to the slave processes."""
+    multiprocessing.map will need to transmit big arrays to the subordinate processes."""
     global resid_f,cgw,cpn
 
     return logL(resid_f,cgw,cpn,A=x[0],n=1,cgwunit='100ns')


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.